### PR TITLE
Extract span from metadata using `joinOrRoot`

### DIFF
--- a/src/main/scala/example/HelloGrpcServer.scala
+++ b/src/main/scala/example/HelloGrpcServer.scala
@@ -8,12 +8,31 @@ import org.typelevel.otel4s.trace.Tracer
 import cats.effect.std.Console
 import cats.Monad
 import cats.syntax.all._
+import org.typelevel.otel4s.context.propagation.TextMapGetter
 
 class HelloGrpcServer[F[_]: Tracer: Console: Monad]
     extends GreeterFs2Grpc[F, Metadata] {
   override def sayHello(request: HelloRequest, ctx: Metadata): F[HelloReply] =
-    Tracer[F].span("sayHello").surround {
-      Console[F].println(s"Received: ${request.name}") *>
-        Monad[F].pure(HelloReply(s"Hello, ${request.name}"))
+    Tracer[F].joinOrRoot(ctx) {
+      Tracer[F].currentSpanContext.flatTap(ctx =>
+        Console[F].println(s"Parent context: $ctx")
+      ) >>
+        Tracer[F].span("sayHello").surround {
+          Console[F].println(s"Received: ${request.name}") *>
+            Monad[F].pure(HelloReply(s"Hello, ${request.name}"))
+        }
+    }
+
+  private implicit val metadataTextMapGetter: TextMapGetter[Metadata] =
+    new TextMapGetter[Metadata] {
+      import scala.jdk.CollectionConverters._
+
+      def get(carrier: Metadata, key: String): Option[String] =
+        Option(
+          carrier.get(Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER))
+        )
+
+      def keys(carrier: Metadata): Iterable[String] =
+        carrier.keys().asScala
     }
 }


### PR DESCRIPTION
The output is:

```
[info] Parent context: Some(SpanContext{traceId=0af7651916cd43dd8448eb211c80319c, spanId=b7ad6b7169203331, traceFlags=01, traceState=TraceState{entries={}}, remote=true, valid=true})
[info] Received: bob
```